### PR TITLE
Reduce required namespace mapping via manually generated user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:edge
 RUN apk add --no-cache curl tor && rm -rf /var/cache/apk/* && \
     sed "1s/^/SocksPort 0.0.0.0:9050\n/" /etc/tor/torrc.sample > /etc/tor/torrc
 
+RUN sed -i '/tor:x:/d' /etc/passwd && sed -i 's/65533:tor/65533:/' /etc/group && \
+    addgroup -g 101 -S toranon && adduser -S -D -H -u 100 -s /sbin/nologin -G toranon -g toranon toranon
+
 EXPOSE 9050 9051
 
 HEALTHCHECK --interval=300s --timeout=15s --start-period=60s --start-interval=10s \
@@ -10,5 +13,5 @@ HEALTHCHECK --interval=300s --timeout=15s --start-period=60s --start-interval=10
 
 VOLUME ["/var/lib/tor"]
 
-USER tor
+USER toranon
 CMD ["tor"]


### PR DESCRIPTION
Replace apk tor user with generated toranan user and group to reduce required namespace mapping from full 65535 range to 102 range. UID 100 is used to match original tor UID while GID 101 is used to avoid existing group.