### PR TITLE
Added a better Healthcheck logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Tor Control Port Address
+# The address:port where the Tor Control Port is listening
+# Default: 127.0.0.1:9051 (container-internal)
+# For external Tor server: TOR_CONTROL_ADDR=192.168.1.100:9051
+TOR_CONTROL_ADDR=127.0.0.1:9051
+
+# Tor Control Port Password
+# This password is used by the healthcheck to authenticate with the Tor control port
+# Change this to a secure password if you want to use the Control Port anywhere else than localhost!!!
+TOR_CONTROL_PASSWORD=password
+
+# Optional: Enable debug mode for troubleshooting
+# DEBUG=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
 # syntax=docker/dockerfile:1
 
+FROM golang:alpine AS builder
+
+WORKDIR /build
+COPY healthcheck/main.go .
+RUN go build -ldflags="-s -w" -o healthcheck main.go
+
 FROM alpine:edge
 
-RUN apk add --no-cache curl tor && rm -rf /var/cache/apk/* && \
-    sed "1s/^/SocksPort 0.0.0.0:9050\n/" /etc/tor/torrc.sample > /etc/tor/torrc
+RUN apk add --no-cache tor && rm -rf /var/cache/apk/*
+
+COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Fallbacks
+ENV TOR_CONTROL_ADDR=127.0.0.1:9051
+ENV TOR_CONTROL_PASSWORD=password
 
 EXPOSE 9050 9051
 
-HEALTHCHECK --interval=300s --timeout=15s --start-period=60s --start-interval=10s \
-    CMD curl -x socks5h://127.0.0.1:9050 'https://check.torproject.org/api/ip' | grep -qm1 -E '"IsTor"\s*:\s*true'
+HEALTHCHECK --interval=600s --timeout=30s --start-period=60s --start-interval=60s \
+    CMD ["/usr/local/bin/healthcheck"]
 
 VOLUME ["/var/lib/tor"]
 
 USER tor
-CMD ["tor"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go build -ldflags="-s -w" -o healthcheck main.go
 
 FROM alpine:edge
 
-RUN apk add --no-cache tor && rm -rf /var/cache/apk/*
+RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/*
 
 COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN go build -ldflags="-s -w" -o healthcheck main.go
 
 FROM alpine:edge
 
-RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/* && \
-    sed "1s/^/SocksPort 0.0.0.0:9050\n/" /etc/tor/torrc.sample > /etc/tor/torrc
 RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/*
 
 COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN set -eu && \
     bash \
     nyx \
     lyrebird && \
-    rm -rf /tmp/* /var/cache/apk/* 
+    rm -rf /tmp/* /var/cache/apk/* && \
+    sed "1s/^/SocksPort 0.0.0.0:9050\n/" /etc/tor/torrc.sample > /etc/tor/torrc
 
 COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck
 COPY entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/* && \
 RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/*
 
 COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Fallbacks
 ENV TOR_CONTROL_ADDR=127.0.0.1:9051
@@ -29,5 +29,5 @@ VOLUME ["/etc/tor"]
 VOLUME ["/var/lib/tor"]
 
 USER tor
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,16 @@ RUN go build -ldflags="-s -w" -o healthcheck main.go
 
 FROM alpine:edge
 
-RUN apk add --no-cache tor bash nyx lyrebird && rm -rf /var/cache/apk/*
+RUN set -eu && \
+    apk update && \
+    apk upgrade && \
+    apk --no-cache add \
+    curl \
+    tor \
+    bash \
+    nyx \
+    lyrebird && \
+    rm -rf /tmp/* /var/cache/apk/* 
 
 COPY --from=builder /build/healthcheck /usr/local/bin/healthcheck
 COPY entrypoint.sh /usr/local/bin/

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,14 @@
 services:
   tor:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: dockurr/tor
     container_name: tor
+    environment:
+      - TOR_CONTROL_PASSWORD=password
+      # Optional: Connect healthcheck to external Tor server
+      # - TOR_CONTROL_ADDR=192.168.1.100:9051
     ports:
       - 9050:9050
       - 9051:9051

--- a/compose.yml
+++ b/compose.yml
@@ -1,14 +1,9 @@
 services:
   tor:
-    build:
-      context: .
-      dockerfile: Dockerfile
     image: dockurr/tor
     container_name: tor
     environment:
       - TOR_CONTROL_PASSWORD=password
-      # Optional: Connect healthcheck to external Tor server
-      # - TOR_CONTROL_ADDR=192.168.1.100:9051
     ports:
       - 9050:9050
       - 9051:9051

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+# Get control password from environment (default: "password")
+TOR_CONTROL_PASSWORD="${TOR_CONTROL_PASSWORD:-password}"
+
+echo "Generating Tor control port password hash..."
+
+# Generate hashed password using Tor
+# tor --hash-password outputs the hash on the last line
+HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" | tail -n 1)
+
+if [ -z "$HASHED_PASSWORD" ]; then
+    echo "ERROR: Failed to generate password hash" >&2
+    exit 1
+fi
+
+echo "Hash generated successfully"
+
+# Create defaults file with default settings for Docker healthcheck
+# These can be overridden by user's /etc/tor/torrc
+cat > /tmp/torrc-defaults <<EOF
+# Default settings required for Docker healthcheck
+# User's /etc/tor/torrc can override any of these settings
+
+# Control port (required for healthcheck)
+# Binds to 127.0.0.1, accessible only within container
+ControlPort 9051
+
+# Control port password (generated from TOR_CONTROL_PASSWORD environment variable)
+HashedControlPassword $HASHED_PASSWORD
+EOF
+
+# Check if user provided custom torrc
+if [ ! -f /etc/tor/torrc ]; then
+    echo "WARNING: No custom torrc found at /etc/tor/torrc"
+    echo "WARNING: Using default configuration for Healthcheck!"
+fi
+
+# Start Tor with defaults that can be overridden by /etc/tor/torrc
+# The --defaults-torrc file has lowest priority, user's torrc takes precedence
+exec tor --defaults-torrc /tmp/torrc-defaults "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,6 @@ set -e
 # Get control password from environment (default: "password")
 TOR_CONTROL_PASSWORD="${TOR_CONTROL_PASSWORD:-password}"
 
-echo "Generating Tor control port password hash..."
-
 # Generate hashed password using Tor
 # tor --hash-password outputs the hash on the last line
 HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" | tail -n 1)
@@ -14,8 +12,6 @@ if [ -z "$HASHED_PASSWORD" ]; then
     echo "ERROR: Failed to generate password hash" >&2
     exit 1
 fi
-
-echo "Hash generated successfully!"
 
 # Create defaults file with default settings for Docker healthcheck
 # These can be overridden by user's /etc/tor/torrc
@@ -30,12 +26,6 @@ ControlPort 9051
 # Control port password (generated from TOR_CONTROL_PASSWORD environment variable)
 HashedControlPassword $HASHED_PASSWORD
 EOF
-
-# Check if user provided custom torrc
-if [ ! -f /etc/tor/torrc ]; then
-    echo "WARNING: No custom torrc found at /etc/tor/torrc"
-    echo "WARNING: Using default configuration for Healthcheck!"
-fi
 
 # Start Tor with defaults that can be overridden by /etc/tor/torrc
 # The --defaults-torrc file has lowest priority, user's torrc takes precedence

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [ -z "$HASHED_PASSWORD" ]; then
     exit 1
 fi
 
-echo "Hash generated successfully"
+echo "Hash generated successfully!"
 
 # Create defaults file with default settings for Docker healthcheck
 # These can be overridden by user's /etc/tor/torrc

--- a/healthcheck/main.go
+++ b/healthcheck/main.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Configuration loaded from environment variables. Contains defaults if none are set.
+var (
+	controlAddr     = getEnv("TOR_CONTROL_ADDR", "127.0.0.1:9051")
+	controlPassword = getEnv("TOR_CONTROL_PASSWORD", "password")
+	debugMode       = getEnv("DEBUG", "false") == "true"
+)
+
+const (
+	onionooAPIURL = "https://onionoo.torproject.org/details?lookup=%s"
+	timeout       = 10 * time.Second
+)
+
+// getEnv reads an environment variable or returns a default value
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+type OnionooResponse struct {
+	Version         string `json:"version"`
+	RelaysPublished string `json:"relays_published"`
+	Relays          []struct {
+		Nickname    string   `json:"nickname"`
+		Fingerprint string   `json:"fingerprint"`
+		Running     bool     `json:"running"`
+		Flags       []string `json:"flags"`
+	} `json:"relays"`
+	Bridges []interface{} `json:"bridges"`
+}
+
+func main() {
+	if err := healthcheck(); err != nil {
+		fmt.Fprintf(os.Stderr, "Healthcheck failed: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func healthcheck() error {
+	// Connect to Tor Control Port
+	conn, err := net.DialTimeout("tcp", controlAddr, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to connect to control port: %w", err)
+	}
+	defer conn.Close()
+
+	// Set a deadline for the connection
+	err = conn.SetDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return err
+	}
+	reader := bufio.NewReader(conn)
+
+	// Authenticate with Tor Control Port
+	if err := authenticate(conn, reader); err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	// Get fingerprint from Control Port
+	fingerprint, err := getFingerprint(conn, reader)
+	if err != nil {
+		return fmt.Errorf("failed to get fingerprint: %w", err)
+	}
+
+	// Query Onionoo API
+	if err := checkOnionoo(fingerprint); err != nil {
+		return fmt.Errorf("onionoo check failed: %w", err)
+	}
+
+	return nil
+}
+
+func authenticate(conn net.Conn, reader *bufio.Reader) error {
+	// Send AUTHENTICATE command with the plaintext password
+	// Tor performs S2K hashing internally and validates against HashedControlPassword which is set in torrc
+	// To set HashedControlPassword, run `tor --hash-password <password>` and put the result in torrc
+	cmd := fmt.Sprintf("AUTHENTICATE \"%s\"\r\n", controlPassword)
+
+	if _, err := conn.Write([]byte(cmd)); err != nil {
+		return err
+	}
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(response, "250") {
+		return fmt.Errorf("authentication failed: %s", strings.TrimSpace(response))
+	}
+
+	return nil
+}
+
+func getFingerprint(conn net.Conn, reader *bufio.Reader) (string, error) {
+	if _, err := conn.Write([]byte("GETINFO fingerprint\r\n")); err != nil {
+		return "", err
+	}
+
+	// Parse response
+	var fingerprint string
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+
+		line = strings.TrimSpace(line)
+
+		// Debug: Show raw response from Tor Control Protocol
+		if debugMode {
+			fmt.Fprintf(os.Stderr, "DEBUG: Tor response: %q\n", line)
+		}
+
+		// Looks for the Fingerprint line
+		if strings.HasPrefix(line, "250-fingerprint=") {
+			fingerprint = strings.TrimPrefix(line, "250-fingerprint=")
+			// Removes spaces to be compatible with Onionoo API
+			fingerprint = strings.ReplaceAll(fingerprint, " ", "")
+			// Convert to uppercase for Onionoo API
+			fingerprint = strings.ToUpper(fingerprint)
+		} else if strings.HasPrefix(line, "250 ") {
+			// End of response
+			break
+		} else if strings.HasPrefix(line, "551") {
+			// Not running as relay
+			return "", fmt.Errorf("not running as a relay: %s", line)
+		}
+	}
+
+	if fingerprint == "" {
+		return "", fmt.Errorf("fingerprint not found in response")
+	}
+
+	// Validation: must be 40 characters long
+	if len(fingerprint) != 40 {
+		return "", fmt.Errorf("invalid fingerprint length: got %d chars, expected 40", len(fingerprint))
+	}
+
+	// Validation: must only contain hex characters
+	for _, char := range fingerprint {
+		if !((char >= '0' && char <= '9') || (char >= 'A' && char <= 'F')) {
+			return "", fmt.Errorf("invalid fingerprint: contains non-hex character '%char'", char)
+		}
+	}
+
+	return fingerprint, nil
+}
+
+func checkOnionoo(fingerprint string) error {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	url := fmt.Sprintf(onionooAPIURL, fingerprint)
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to query onionoo API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("onionoo API returned status %d", resp.StatusCode)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var onionoo OnionooResponse
+	if err := json.Unmarshal(buf.Bytes(), &onionoo); err != nil {
+		return fmt.Errorf("failed to parse onionoo response: %w", err)
+	}
+
+	// Checks if the relay is, consensus-wise, running
+	if len(onionoo.Relays) == 0 {
+		return fmt.Errorf("relay %s not found in onionoo database (new relays may take hours to appear)", fingerprint)
+	}
+
+	relay := onionoo.Relays[0]
+
+	// Print relay details
+	fmt.Fprintf(os.Stderr, "Found relay: %s (fingerprint: %s)\n", relay.Nickname, relay.Fingerprint)
+
+	// Return error if fingerprints don't match
+	if !strings.EqualFold(relay.Fingerprint, fingerprint) {
+		return fmt.Errorf("fingerprint mismatch: requested %s, got %s", fingerprint, relay.Fingerprint)
+	}
+
+	// Return error if relay is not running
+	if !relay.Running {
+		return fmt.Errorf("relay %s is not running according to onionoo", relay.Nickname)
+	}
+
+	// Return error if relay has no flags
+	if len(relay.Flags) == 0 {
+		return fmt.Errorf("relay %s has no flags (not yet in consensus or not listed)", relay.Nickname)
+	}
+
+	// Log successful validation
+	fmt.Fprintf(os.Stderr, "Relay is running with flags: %v\n", relay.Flags)
+
+	return nil
+}

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,97 @@ services:
 docker run -it --rm --name tor -p 9050:9050 -p 9051:9051 -v "${PWD:-.}/config:/etc/tor" -v "${PWD:-.}/data:/var/lib/tor dockurr/tor"
 ```
 
+## Configuration 🔧
+
+The container supports custom Tor configuration via mounted `torrc` file at `/etc/tor/torrc`.
+
+**Environment Variables:**
+
+- `TOR_CONTROL_ADDR` - Address of Tor Control Port (default: "127.0.0.1:9051")
+  - Default connects to Tor instance within the same container
+  - For external Tor server: `TOR_CONTROL_ADDR=192.168.1.100:9051`
+  - Useful for monitoring remote relays or separate Tor containers
+
+- `TOR_CONTROL_PASSWORD` - Password for Tor control port (default: "password")
+  - The container automatically generates the required hash
+  - Change this for production deployments
+  - Example: `TOR_CONTROL_PASSWORD=mySecurePassword123`
+
+- `DEBUG` - Enable debug output (default: "false")
+  - Set to "true" for troubleshooting
+  - Shows raw Tor Control Protocol responses
+
+**Default Settings:**
+
+- `SocksPort 0.0.0.0:9050` - SOCKS proxy enabled
+- `ControlPort 127.0.0.1:9051` - Control port for healthcheck (container-local)
+- `HashedControlPassword` - Generated automatically from `TOR_CONTROL_PASSWORD`
+
+**Custom Configuration:**
+
+You can provide your own `torrc` file with relay, exit node, or hidden service settings. The container will:
+- Use your custom settings as the primary configuration
+- Apply defaults only for options you don't specify
+- Ensure required healthcheck settings are available
+
+**Example with custom password:**
+
+```yaml
+services:
+  tor:
+    image: dockurr/tor
+    environment:
+      - TOR_CONTROL_PASSWORD=mySecurePassword123
+    ports:
+      - 9050:9050
+    volumes:
+      - ./config:/etc/tor
+      - ./data:/var/lib/tor
+```
+
+**Example custom torrc:**
+
+```
+# Your relay configuration
+Nickname MyTorRelay
+ContactInfo your@email.com
+ORPort 9050
+DirPort 9030
+ExitRelay 0
+ExitPolicy reject *:*
+
+# SocksPort and ControlPort are set by default if not specified
+# To override, simply add your own settings here
+```
+
+## Development & Testing 🧪
+
+**Testing the healthcheck locally:**
+
+When testing `healthcheck/main.go` outside the container with `go run main.go`, you must set environment variables on your **host system** (not in compose.yml):
+
+```bash
+# Windows PowerShell
+$env:TOR_CONTROL_PASSWORD="yourpassword"
+go run healthcheck/main.go
+
+# Windows CMD
+set TOR_CONTROL_PASSWORD=yourpassword
+go run healthcheck\main.go
+
+# Linux/macOS
+export TOR_CONTROL_PASSWORD=yourpassword
+go run healthcheck/main.go
+```
+
+**Important:** compose.yml environment variables only apply **inside the container**. For full end-to-end testing, build and run the container:
+
+```bash
+docker compose build
+docker compose up -d
+docker compose logs -f tor
+```
+
 ## Stars 🌟
 [![Stars](https://starchart.cc/dockur/tor.svg?variant=adaptive)](https://starchart.cc/dockur/tor)
 


### PR DESCRIPTION
**Warning**: This is just a proof of concept for now! It is not yet prod ready but I wanted to open up a discussion on this and ask people to TEST it. Maybe we could have, next to the Master Branch a Testing/Dev branch for these kind of things?

Hey!

The current health check, respectfully, kinda sucks. It only works in certain scenarios and doesn't really take into account the consent of the network. So I took the basic idea of the current Health check, see if our Relay is Working and if Tor considered it a Tor-Relay.
The Goal for me was to:
- Ensure that the Docker Health check takes into account the consent of the Tor-Network
    - To do this we use the official [Onionoo API](https://metrics.torproject.org/onionoo.html)
- I do not add any external dependencies in my binary
    - Standard Lib only!
- The Tor-Container stays free of additional dependencies
    - This is done via a Multistage build
- It stays fairly hassle free for the end user (this comes with a caveat I'll explain later).


The new shiny version of the Health check does the following:

- Uses the Control Port to extract the Fingerprint of the Relay
  - We use the [GETINFO](https://spec.torproject.org/control-spec/commands.html#getinfo)-Command for that.
- With this Fingerprint we do a simple API-Request to the /details endpoint of Onionoo
  - Within this we find loads of helpful information for the relay such as the [running](https://metrics.torproject.org/onionoo.html#details_relay_running)-Value or all of the [flags](https://metrics.torproject.org/onionoo.html#details_relay_flags) a relay can have.
  - Mind you these are all information directly from the Network: We automatically know and ensure that, consensus-wise, our Docker Container does indeed what we want it to.

For now the logic is fairly simple. It only checks if the Relay is, consensus wise up and running. As I do not have a Guard Relay i was only able to test the Bare-Minimum myself.
If there are any errors they will be returned within the main function as Code 1, therefore the Health check logic of Docker will interpret this as "unhealthy". If everything runs nicely we get Code 0, and Docker knows that everything is A-Okay :-)

**Current Caveats:**
Currently I use a very, very insecure authentication method for the Control Port. My Excuse is, that by default I only use this within the Docker Container. The Control Port is bound to localhost (127.0.0.1), so using "password" is an excusable default. The Problem, and reason for this approach is: The Relay saves the [Authentication method](https://spec.torproject.org/control-spec/implementation-notes.html#authentication) in the torrc file, hashed as S2K. So for this health check to even run we need to set a default.

But, again, I'm opening this PR because I want to put essentially everything here up for discussion.